### PR TITLE
Creating a generic "package" installation API

### DIFF
--- a/lib/brew.sh
+++ b/lib/brew.sh
@@ -121,6 +121,12 @@ function cache-or-command() {
   cat "${file}"
 }
 
+# @description For each passed argument checks if it's installed.
+# @return 0 when all packages in the list are instealled, 1 otherwise
+function package.is-installed() {
+  [[ "$(brew.package.is-installed "$@")" == "true" ]]
+}
+
 function brew.package.is-installed() {
   if brew.package.all-installed "$@"; then
     echo "true"
@@ -166,6 +172,15 @@ function brew.reinstall.package() {
   # brew.cache-reset.delayed
 
   brew.install.package "${package}"
+}
+
+function package.uninstall() {
+  brew.uninstall.packages "$@"    
+}
+
+function package.install() {
+  brew.install.packages "$@"    
+  hash -r 2>/dev/null
 }
 
 function brew.install.package() {

--- a/lib/file.sh
+++ b/lib/file.sh
@@ -280,6 +280,12 @@ file.extension.replace() {
   done
 }
 
+file.sync() {
+  local from="$1"
+  local to="$2"
+
+}
+
 file.find() {
   find . -name "*$1*" -type f -print
 }

--- a/lib/is.sh
+++ b/lib/is.sh
@@ -239,6 +239,10 @@ function is.command() {
   command -v "$1" >/dev/null
 }
 
+function is.a-command() {
+  is.command "$@"
+}
+
 function is.missing() {
   ! is.command "$@"
 }

--- a/lib/package.sh
+++ b/lib/package.sh
@@ -1,0 +1,30 @@
+# @description fr
+function package.ensure.is-installed() {
+  for pkg in "$@"; do 
+    package.is-installed ${pkg} || package.install
+    package.is-installed ${pkg} || {
+      error "Package ${pkg} does not appear installed, broken package or version?"
+      return 1
+    }
+  done
+} 
+
+# @descrtipion Verifies that a particular binary was succesfully instealled
+#              in cases where it might differenht from the package name.
+#
+# @example package.ensure-command-available ruby gem
+#          In this example we skip installation if `gem` exists and in the PATH.
+#          Oherwise we install the package and retry, and return if not found
+#
+function package.ensure.commmand-available() {
+  local package="$1";  shift
+  local binary="$1";  shift
+
+  is.a-command "${binary}" && return 0
+  package.ensure.is-installed "${package}"
+  hash -r 1>/dev/null 2>&1
+  is.a-command "${binary}" && return 0
+
+  error "After installing package ${package}, binary ${binary} still is not found."
+}
+

--- a/lib/path.sh
+++ b/lib/path.sh
@@ -9,6 +9,13 @@
 
 # 1. Functional methods, no mutations of global variables:
 #
+
+# @description Removes a trailing slash from an argument path
+function path.strip-slash() {
+    local path="$(echo "$1" | sed -E 's#\/+$##g')"
+    printf -- "%s" "${path}"
+}
+
 # @description Prints a new-line separated list of paths in PATH
 # @arg1 A path to split, defaults to $PATH
 function path.dirs() {

--- a/lib/video.sh
+++ b/lib/video.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# vim: ft=bash
+# @copyright © 2016-2021 Konstantin Gredeskoul, All rights reserved
+# @license MIT License.
+# 
+# @file is.sh
+# @description video conversions
+
+
+# Installs ffmpeg
+.ensure.ffmpeg() {
+
+  is.a-command ffmpeg && return 0
+  package.is-installed ffmpeg || package.install ffmpeg
+  is.a-command ffmpeg && return 0
+
+  error "Can't find ffmpeg after installation."
+  return 1
+}
+
+video.convert.compress() {
+  local file="$1"; shift
+  local output=${file/\.*/.mkv}
+  local ratio="${2:-"1"}"
+
+  [[ "${file}" == "${output}" ]] && output="${output/\.mkv/-smaller-${ratio}.mkv}"
+  
+  h2 "Starting ffmpeg conversion from ${file} to ${output}" \
+     "Source file size is $(file.size.mb ${file})"
+  
+  run.set-next show-output-on
+  run "ffmpeg -stats -y -i ${file} -preset:v veryfast -loglevel error -c:v libx265 -crf 22 -c:a copy -vf 'scale=iw/3:ih/3' ${output}"
+  
+  local before=$(file.size ${file})
+  local after=$(file.size ${output})
+  local reduction=$(( 100 * ( before - after ) / before ))
+
+  success "File ${output} was prodiced with ${reduction}% size savings."  
+}

--- a/test/path_test.bats
+++ b/test/path_test.bats
@@ -9,7 +9,16 @@ source lib/path.sh
 source lib/is.sh
 set -e
 
-@test "path.dirs.size" {
+@test "path.strip-slash" {
+  local p1="/Users/kig/"
+  local p2="/Users/kig"
+  local p3="/Users/kig///"
+  for p in $p1 $p2 $p3; do
+    [ "$(path.strip-slash $p)" == "/Users/kig" ]
+  done
+}
+
+@test "path.size" {
   local LONG="/bin:/bin:/usr/local/bin:/usr/bin:/bin"
   [ "$(path.dirs.size "${LONG}")" -eq 5 ]
 }


### PR DESCRIPTION
The idea is to have several generic `package.install` and `package.uninstall` methods that underneath utilize OS-dependent mechanism such as `apt-get install` or `brew indstall`.