### PR TITLE
Fixes #59 — option to not load bashmatic at login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ make-utf8:			## Convert all text SHELL script  files from ASCII to UTF8 format
 file-stats-git:			## Print all  files  known to `git ls-files` command
 				@git ls-files | xargs files
 
+#—————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+
+update: 			update-changelog update-functions update-usage update-readme fonts-clean git-add ## Runs all of the updates, add locally modiofied files to git.
 
 update-changelog: 		## Auto-generate the doc/CHANGELOG (requires GITHUB_TOKEN env var set)
 				@printf "\n$(bold)  👉    $(red)$(clear)  $(green)Regenerating CHANGELOG....$(clear)\n"
@@ -106,13 +109,13 @@ reduce-size-readme:
 open-readme:			## Open README.pdf in the system viewer
 				@[[ -s README.pdf ]] && open -n README.pdf
 
+#—————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 git-add:
 				@printf "\n$(bold)  👉  $(yellow)Git status after the update:$(clear)\n"
 				@git add .
 				@printf "\n$(bold)  👉  $(blue)Git status after the update:$(clear)\n"
 				@git status
 
-update: 			update-changelog update-functions update-usage update-readme fonts-clean git-add ## Runs all of the updates, add locally modiofied files to git.
 
 setup: 				## Run the comprehensive development setup on this machine
 				@printf "\n$(bold)  👉    $(red)$(clear)  $(green)Running developer setup script, this may take a while.$(clear)\n"

--- a/bin/bashmatic
+++ b/bin/bashmatic
@@ -20,7 +20,15 @@
 [[ -z ${BASHMATIC_HOME} ]] && export BASHMATIC_HOME="$(dirname $(cd $(dirname "${BASH_SOURCE[0]:-${(%):-%x}}") || exit 1; pwd -P))"
 source "${BASHMATIC_HOME}/init.sh"
 
-if is.a-function "$1"; then
-  eval "$@"
+__func="$1"
+shift
+
+if is.a-function "${__func}"; then
+  eval "${__func} $@"
+elif is.a-function "bashmatic.${__func}"; then
+  eval "bashmatic.${__func} $@"
+else
+  error "Can't find a valid function based on the argument ${bldylw}${__func}"
+  exit 1
 fi
 

--- a/bin/bashmatic-install
+++ b/bin/bashmatic-install
@@ -55,12 +55,20 @@ ts() {
 }
 
 puts() {
-  printf "${bldblu} INFO  ${txtpur}〈$(ts)〉 ${txtcyn}${*}${clr}\n"
+  for str in "$@"; do
+  printf "${clr}${bldwht}${bakblu} INFORMATION ➜ ${clr}  ${txtblu}${str}${clr}\n"
+  done
 }
 
 err() {
   for str in "$@"; do
-    printf "${bldred} ERROR ${txtpur}〈$(ts)〉 ${bldred}${str}\n"
+  printf "${clr}${bldwht}${bakred} ERROR       ➜ ${clr}  ${bldred}${str}${clr}\n"
+  done
+}
+
+wrn() {
+  for str in "$@"; do
+  printf "${clr}${txtblk}${bakylw} WARNING     ➜ ${clr}  ${bldylw}${str}${clr}\n"
   done
 }
 
@@ -179,16 +187,18 @@ git-sync() {
   [[ -d ".git" ]] || return
 
   if [[ -n $(git status -s) ]]; then
-    echo
-    err "Previous installation folder has locally modified files." \
-      "Commit, stash or remove those files, and try again."
+    wrn "It appears you already installed Bashmatic into ${BASHMATIC_HOME}." \
+        "Normally we would pull the latest changes during this operation," \
+        "but we detected locally modified files under ${bldwht}${BASHMATIC_HOME}."
 
+    puts "Please commit, stash or remove those files, and try again."
+    puts "For your information, here are the modifications:"      
     echo
     git status -s || true
     echo
     return 1
   else
-    git checkout -q master && git pull -q --rebase
+    git checkout -q master && git pull -q --rebase >/dev/null
   fi
 
   cd - >/dev/null
@@ -315,6 +325,7 @@ export bootstrap__skip_git_check=0
 export bootstrap__skip_install=0
 export bootstrap__verbose=0
 export bootstrap__quiet=0
+export bootstrap__skip_on_login=0
 export bootstrap__bashmatic_home=${HOME}/.bashmatic
 export bootstrap__bash_version="5.1-rc2"
 export bootstrap__bash_prefix="/usr/local"
@@ -345,8 +356,22 @@ ${bldylw}FLAGS:${clr}
   -H, --bashmatic-home PATH     Install bashmatic into PATH (default: ${bootstrap__bashmatic_home})
   -V, --bash-version VERSION    Install BASH VERSION (default: ${bootstrap__bash_version})
   -P, --bash-prefix PATH        Install BASH into PATH (default: ${bootstrap__bash_prefix})
+
+  -l, --skip-on-login           Do not install Bashmatic Hook into your dotfiles, which
+                                it does by the default. If you skip it, you can always
+                                change your mind later and add it to your shell dot files
+                                by running the following on the command line:
+
+                                You can always do so later with the following:
+                                ${bldgrn}$ ~/.bashmatic/bin/bashmatic load-at-login ${clr}
+
+                                This above will install the Bashmatic hook into your shell 
+                                dotfile, eg ${txtcyn}~/.bash_profile.${clr} if you are on BASH,
+                                or ${txtcyn}~/.zshrc${clr} if you are on ZSH..
+
   -g, --skip-git                Do not abort if the destination has local changes
   -i, --skip-install            Only install/verify prerequisites, skip install.
+
   -v, --verbose                 See additional output as bootstrap is running.
   -q, --quiet                   See only error output.
   -d, --debug                   Turn on 'set -x' to see all commands running.
@@ -400,6 +425,10 @@ parse-opts() {
       shift
       export bootstrap__skip_install=1
       ;;
+    -l | --skip-on-login)
+      shift
+      export bootstrap__skip_on_login=1
+      ;;
     -h | -\? | --help)
       shift
       usage
@@ -429,7 +458,7 @@ bashmatic-download-and-install() {
   if [[ -d ${BASHMATIC_HOME} && -f ${BASHMATIC_HOME}/init.sh ]]; then
     git-sync || return 1
   else
-    git clone -q ${BASHMATIC_URL} "${BASHMATIC_HOME}"
+    git clone -q ${BASHMATIC_URL} "${BASHMATIC_HOME}" >/dev/null
     code=$? 
   fi
 
@@ -445,7 +474,7 @@ bashmatic-download-and-install() {
      }
     # shellcheck disable=SC1090
     source "${BASHMATIC_INIT}"
-    bashmatic.load-at-login
+    ((bootstrap__skip_on_login)) || bashmatic.load-at-login
     is-quiet || success "Your BashMatic has been successfully installed."
     return 0
   fi

--- a/lib/user.sh
+++ b/lib/user.sh
@@ -129,7 +129,7 @@ user.login-shell-init-file() {
 }
 
 user.current-shell-init-file() {
-  declare -a shell_files=($(util.shell-init-files user.current-shell))
+  declare -a shell_files=($(util.shell-init-files "$(user.current-shell)"))
   .user.pick-shell-init-file "${shell_files[@]}"
 }
 


### PR DESCRIPTION
 * added -l flag to `bin/bashmatic-install` to not invoke `bashmatic-load-at-login` function.

 * Additionally, enhance the `bin/bashmatic` helper to 
    1. try to execute `bashmatic.$1` if defined, and
    2. report an error if no function under either name is found.

## `bin/bashmatic-install --help`

![Screen Shot 2021-04-21 at 2 42 40 PM](https://user-images.githubusercontent.com/259982/115624694-d4e9ca00-a2af-11eb-8366-fc1ad5262ca4.png)
